### PR TITLE
Add Python 3.0 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 from setuptools import setup
+import sys
+
+extra = {}
+if sys.version_info >= (3,):
+    extra['use_2to3'] = True
 
 setup(
     name = 'microdata',
@@ -11,4 +16,5 @@ setup(
     scripts = ['microdata.py'],
     test_suite = 'test',
     install_requires = ['html5lib'],
+    **extra
 )


### PR DESCRIPTION
Use 2to3 while installing package.
