### PR TITLE
Added support for multiple html5lib tree builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 microdata
 =========
 
-[![Build Status](https://secure.travis-ci.org/edsu/microdata.png)](http://travis-ci.org/edsu/microdata)
+[![Build Status](https://travis-ci.org/Rsx200/microdata-lxml.svg)](http://travis-ci.org/Rsx200/microdata-lxml)
 
 microdata.py is a small utility library for extracting 
 [HTML5 Microdata](http://dev.w3.org/html5/md/) from 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ For more about HTML5 Microdata check out Mark Pilgrim's
 [chapter](http://diveintohtml5.org/extensibility.html) on on it in 
 [Dive Into HTML5](http://diveintohtml5.org/).
 
+Changelog
+------------
+1) Added support for multiple html5lib tree builders - currently only __dom__ and __lxml__ are implemented
+2) Moved parsing functions to Microdata class
+3) Implemented backwards compatibility for the __get_items__ method
+
 Command Line
 ------------
 
@@ -95,11 +101,51 @@ u"http://www.xyz.edu/students/alicejones.html"
 }
 ```
 
+Alternative usage examples, class based:
+
+Treebuilder: __dom__
+```python
+>>> from microdata import Microdata
+>>> import urllib
+>>> url = "https://raw.github.com/edsu/microdata/master/test-data/example.html"
+>>> items = Microdata("dom").get_items(urllib.urlopen(url))
+>>> item = items[0]
+>>> item.itemtype
+[http://schema.org/Person]
+>>> item.name
+u'Jane Doe'
+>>> item.colleagues
+http://www.xyz.edu/students/alicejones.html
+>>> item.get_all('colleagues')
+[http://www.xyz.edu/students/alicejones.html, http://www.xyz.edu/students/bobsmith.html]
+...
+```
+
+Treebuilder: __lxml__
+```python
+>>> from microdata import Microdata
+>>> import urllib
+>>> url = "https://raw.github.com/edsu/microdata/master/test-data/example.html"
+>>> items = Microdata("lxml").get_items(urllib.urlopen(url))
+>>> item = items[0]
+>>> item.itemtype
+[http://schema.org/Person]
+>>> item.name
+u'Jane Doe'
+>>> item.colleagues
+http://www.xyz.edu/students/alicejones.html
+>>> item.get_all('colleagues')
+[http://www.xyz.edu/students/alicejones.html, http://www.xyz.edu/students/bobsmith.html]
+...
+```
+
+
 Authors
 -------
 
 * Ed Summers <ehs@pobox.com>
 * Chris Adams <chris@improbable.com>
+* Razvan Muscalu <muscalu.razvan@hotmail.com>
 
 Lincense
 --------

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ For more about HTML5 Microdata check out Mark Pilgrim's
 Changelog
 ------------
 1) Added support for multiple html5lib tree builders - currently only __dom__ and __lxml__ are implemented
+
 2) Moved parsing functions to Microdata class
+
 3) Implemented backwards compatibility for the __get_items__ method
 
 Command Line
@@ -109,15 +111,6 @@ Treebuilder: __dom__
 >>> import urllib
 >>> url = "https://raw.github.com/edsu/microdata/master/test-data/example.html"
 >>> items = Microdata("dom").get_items(urllib.urlopen(url))
->>> item = items[0]
->>> item.itemtype
-[http://schema.org/Person]
->>> item.name
-u'Jane Doe'
->>> item.colleagues
-http://www.xyz.edu/students/alicejones.html
->>> item.get_all('colleagues')
-[http://www.xyz.edu/students/alicejones.html, http://www.xyz.edu/students/bobsmith.html]
 ...
 ```
 
@@ -127,15 +120,6 @@ Treebuilder: __lxml__
 >>> import urllib
 >>> url = "https://raw.github.com/edsu/microdata/master/test-data/example.html"
 >>> items = Microdata("lxml").get_items(urllib.urlopen(url))
->>> item = items[0]
->>> item.itemtype
-[http://schema.org/Person]
->>> item.name
-u'Jane Doe'
->>> item.colleagues
-http://www.xyz.edu/students/alicejones.html
->>> item.get_all('colleagues')
-[http://www.xyz.edu/students/alicejones.html, http://www.xyz.edu/students/bobsmith.html]
 ...
 ```
 

--- a/microdata.py
+++ b/microdata.py
@@ -11,12 +11,12 @@ except ImportError:
     import simplejson as json
 
 
-def get_items(location, encoding='UTF-8'):
+def get_items(location, tree_builder="dom", encoding='UTF-8'):
     """
     Pass in a file or file-like object and get a list of Items present in the
     HTML document.
     """
-    dom_builder = html5lib.treebuilders.getTreeBuilder("dom")
+    dom_builder = html5lib.treebuilders.getTreeBuilder(tree_builder)
     parser = html5lib.HTMLParser(tree=dom_builder)
     
     if (sys.version_info.major == 3):

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     py_modules = ['microdata'],
     scripts = ['microdata.py'],
     test_suite = 'test',
-    install_requires = ['html5lib'],
+    install_requires = ['html5lib','lxml'],
     **extra
 )

--- a/test.py
+++ b/test.py
@@ -6,13 +6,14 @@ except ImportError:
 import unittest
 
 from microdata import get_items, Item, URI
+from microdata import Microdata
 
 class MicrodataParserTest(unittest.TestCase):
 
-    def test_parse(self):
+    def helper_parse(self, _get_items_method):
 
         # parse the html for microdata
-        items = get_items(open("test-data/example.html"))
+        items = _get_items_method(open("test-data/example.html"))
 
         # this html should have just one main item
         self.assertTrue(len(items), 1)
@@ -49,10 +50,10 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertTrue(isinstance(i["properties"]["address"][0], dict))
         self.assertEqual(i["properties"]["address"][0]["properties"]["addressLocality"][0], "Seattle")
 
-    def test_parse_nested(self):
+    def helper_parse_nested(self, _get_items_method):
 
         # parse the html for microdata
-        items = get_items(open("test-data/example-nested.html"))
+        items = _get_items_method(open("test-data/example-nested.html"))
 
         # this html should have just one main item
         self.assertTrue(len(items), 1)
@@ -85,8 +86,8 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertTrue(isinstance(i["properties"]["location"][0]["properties"]["address"][0], dict))
         self.assertEqual(i["properties"]["location"][0]["properties"]["address"][0]["properties"]["addressLocality"][0], "Philadelphia")
 
-    def test_parse_unlinked(self):
-        items = get_items(open("test-data/unlinked.html"))
+    def helper_parse_unlinked(self, _get_items_method):
+        items = _get_items_method(open("test-data/unlinked.html"))
         self.assertEqual(len(items), 2)
 
         i = items[0]
@@ -104,12 +105,51 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertEqual(i.itemtype, [URI("http://schema.org/PostalAddress")])
         self.assertTrue('Whitworth' in i.streetAddress)
 
-    def test_skip_level(self):
-        items = get_items(open("test-data/skip-level.html"))
+    def helper_skip_level(self, _get_items_method):
+        items = _get_items_method(open("test-data/skip-level.html"))
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].name, "Jane Doe")
 
-        
 
-if __name__ == "__main__":
+    #Tests for backwards compatibility
+    def test_parse_dom(self):
+        self.helper_parse(get_items)
+
+    def test_parse_nested_dom(self):
+        self.helper_parse_nested(get_items)
+
+    def test_parse_unlinked_dom(self):
+        self.helper_parse_unlinked(get_items)
+
+    def test_skip_level_dom(self):
+        self.helper_skip_level(get_items)
+
+    #Tests for dom treebuilder
+    def test_parse_dom(self):
+        self.helper_parse(Microdata("dom").get_items)
+
+    def test_parse_nested_dom(self):
+        self.helper_parse_nested(Microdata("dom").get_items)
+
+    def test_parse_unlinked_dom(self):
+        self.helper_parse_unlinked(Microdata("dom").get_items)
+
+    def test_skip_level_dom(self):
+        self.helper_skip_level(Microdata("dom").get_items)
+
+    #Tests for lxml treebuilder
+    def test_parse_lxml(self):
+        self.helper_parse(Microdata("lxml").get_items)
+
+    def test_parse_nested_lxml(self):
+        self.helper_parse_nested(Microdata("lxml").get_items)
+
+    def test_parse_unlinked_lxml(self):
+        self.helper_parse_unlinked(Microdata("lxml").get_items)
+
+    def test_skip_level_lxml(self):
+        self.helper_skip_level(Microdata("lxml").get_items)    
+
+        
+if __name__ == "_main_":
     unittest.main()


### PR DESCRIPTION
Hello, 

I've implemented support for multiple tree-builders for html5lib, I've ended up in wrapping all the parsing functions into a common class and conditionally defining the helper functions needed, based on the desired tree type; I've also attempted to preserve backwards compatibility by wrapping the get_items function at global level, not really sure if this is sufficient ...

Additionally, I've updated the test cases to account for these changes.

Last but not least, please let me know if anything needs changing, I just needed to use the lxml tree builder for my own project, so I said to myself, why not share this publicly? :)

Note: I'm just a beginner with Python and GitHub so please have patience with me :)

Kind regards,
Razvan
