### PR TITLE
Minor get_items improvements

### DIFF
--- a/microdata.py
+++ b/microdata.py
@@ -11,19 +11,14 @@ except ImportError:
     import simplejson as json
 
 
-def get_items(location, encoding='UTF-8'):
+def get_items(location, encoding=None):
     """
     Pass in a string or file-like object and get a list of Items present in the
     HTML document.
     """
     dom_builder = html5lib.treebuilders.getTreeBuilder("dom")
     parser = html5lib.HTMLParser(tree=dom_builder)
-
-    if (sys.version_info.major == 3):
-        tree = parser.parse(location)
-    else:
-        tree = parser.parse(location, encoding=encoding)
-
+    tree = parser.parse(location, encoding=encoding)
     return _find_items(tree)
 
 

--- a/microdata.py
+++ b/microdata.py
@@ -13,17 +13,17 @@ except ImportError:
 
 def get_items(location, encoding='UTF-8'):
     """
-    Pass in a file or file-like object and get a list of Items present in the
+    Pass in a string or file-like object and get a list of Items present in the
     HTML document.
     """
     dom_builder = html5lib.treebuilders.getTreeBuilder("dom")
     parser = html5lib.HTMLParser(tree=dom_builder)
-    
+
     if (sys.version_info.major == 3):
         tree = parser.parse(location)
     else:
         tree = parser.parse(location, encoding=encoding)
-    
+
     return _find_items(tree)
 
 


### PR DESCRIPTION
Function's documentation has been fixed to specify that it accepts strings and file-like objects.

The current version fails when using `unicode` strings with Python 2 (unless you explicitly use `encoding=None`), because of this check that html5lib performs: https://github.com/html5lib/html5lib-python/blob/master/html5lib/inputstream.py#L143
This pull request fixes that problem and it also allows to pass a encoding value when using Python 3 (there are some cases when you need to do this, as mentioned here: https://github.com/html5lib/html5lib-python/blob/master/README.rst#usage).

I'd like to suggest renaming the `location` parameter too, since it isn't a location or URL. It's an actual HTML document, so something like `stream` or `document` would fit better in my opinion.