### PR TITLE
Ignore <script> tag in content text

### DIFF
--- a/microdata.py
+++ b/microdata.py
@@ -209,6 +209,8 @@ def _text(e):
     chunks = []
     if e.nodeType == e.TEXT_NODE:
         chunks.append(e.data)
+    elif e.tagName == 'script':
+        return ''
     for child in e.childNodes:
         chunks.append(_text(child))
     return ''.join(chunks)

--- a/test-data/example.html
+++ b/test-data/example.html
@@ -15,6 +15,9 @@
         <span itemprop="streetAddress">
           20341 Whitworth Institute
           405 N. Whitworth
+          <script>
+            // Unrelated text
+          </script>
         </span>
         <span itemprop="addressLocality">Seattle</span>,
         <span itemprop="addressRegion">WA</span>

--- a/test.py
+++ b/test.py
@@ -41,6 +41,9 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertEqual(item.address.itemtype, [URI("http://schema.org/PostalAddress")])
         self.assertTrue(item.address.addressLocality, "Seattle")
 
+        # <script> tag should be ignored in the content text
+        self.assertFalse("Unrelated text" in item.address.streetAddress)
+
         # json
         i = json.loads(item.json())
         self.assertEqual(i["properties"]["name"][0], "Jane Doe")


### PR DESCRIPTION
I've run into a few cases where `<script>` tags are embedded along with text content, mainly on product pages.  I assume they are a workaround for limited access CMS's or for special case products.  I can't think of a case where the script's text would be usable microdata text.