### PR TITLE
Supporting itemprops which are nested.

### DIFF
--- a/microdata.py
+++ b/microdata.py
@@ -160,9 +160,10 @@ def _extract(e, item):
         itemprop = _attr(child, "itemprop")
         itemscope = _is_itemscope(child)
         if itemprop and itemscope:
-            nested_item = _make_item(child)
-            unlinked.extend(_extract(child, nested_item))
-            item.set(itemprop, nested_item)
+            for i in itemprop.split(" "):
+                nested_item = _make_item(child)
+                unlinked.extend(_extract(child, nested_item))
+                item.set(i, nested_item)
         elif itemprop:
             value = _property_value(child)
             # itemprops may also be in a space delimited list

--- a/test-data/multiple-props.html
+++ b/test-data/multiple-props.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>multiple props example</title>
+    </head>
+    <body>
+        <article itemscope itemtype="http://schema.org/Article">
+            <header>
+                <h1 class="article-name" itemprop="name">Discovery of new clues to oust the denominator of the future</h1>
+                <h2 class="article-description" itemprop="description">We witnessed the unchallenged declaration of the grain of sand against the wonders of the Universe</h2>
+                <div class="post-meta">
+                    <p class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person">
+                    <span itemprop="affiliation alumniOf" itemscope itemtype="http://schema.org/Organization">
+                    from <span itemprop="name">Stanford University</span>
+                    </span>
+                    by 
+                    <span itemprop="name">John Doe</span> 
+                    and
+                    <span itemprop="name">Jane Dun</span>
+                    -  
+                    <span class="date" data-time="1461924040">
+                    Apr 29, 3016 10:00 am UTC
+                    </span>
+                    </p>
+                </div>
+            </header>
+        </article>
+        <div itemscope>
+            <span itemprop="favorite-color favorite-fruit">orange</span>
+        </div>
+    </body>
+</html>

--- a/test.py
+++ b/test.py
@@ -112,7 +112,30 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].name, "Jane Doe")
 
-        
+    def test_parse_multiple_props(self):
+        items = get_items(open("test-data/multiple-props.html"))
+
+        self.assertEqual(len(items), 2)
+
+        item = items[0]
+        i = json.loads(item.json())
+        # both names `John Doe and Jane Dun` should appear under author and creator props
+        self.assertEqual(len(i["properties"]["author"][0]["properties"]["name"]), 2)
+        self.assertEqual(i["properties"]["author"][0]["properties"]["name"], ["John Doe", "Jane Dun"])
+        self.assertTrue(len(i["properties"]["creator"][0]["properties"]["name"]), 2)
+        self.assertEqual(i["properties"]["creator"][0]["properties"]["name"], ["John Doe", "Jane Dun"])
+
+        # nested multiple props
+        self.assertEqual(item.author.affiliation.name, "Stanford University")
+        self.assertEqual(item.creator.affiliation.name, "Stanford University")
+        self.assertEqual(item.author.alumniOf.name, "Stanford University")
+        self.assertEqual(item.creator.alumniOf.name, "Stanford University")
+
+        item = items[1]
+        i = json.loads(item.json())
+        # test case for original issue #3
+        self.assertTrue(i["properties"]["favorite-color"][0], "orange")
+        self.assertTrue(i["properties"]["favorite-fruit"][0], "orange")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Extending @robhammond's solution for itemprops delimited by spaces as given [here](https://www.w3.org/TR/microdata/#unordered-set-of-unique-space-separated-tokens) and in issue #3.

Added tests cases for multiple itemprops nested in multiple itemprops.
