### PR TITLE
Relative to absolute

### DIFF
--- a/microdata.py
+++ b/microdata.py
@@ -181,7 +181,7 @@ def _extract(e, item, url=""):
             unlinked.extend(_extract(child, nested_item, url=url))
             item.set(itemprop, nested_item)
         elif itemprop:
-            value = _property_value(child)
+            value = _property_value(child, domain=url)
             # itemprops may also be in a space delimited list
             for i in itemprop.split(" "):
                 item.set(i, value)
@@ -210,11 +210,11 @@ def _is_itemscope(e):
     return _attr(e, "itemscope") is not None
 
 
-def _property_value(e):
+def _property_value(e, domain=""):
     value = None
     attrib = property_values.get(e.tagName, None)
     if attrib in ["href", "src"]:
-        value = URI(e.getAttribute(attrib))
+        value = URI(e.getAttribute(attrib), domain)
     elif attrib:
         value = e.getAttribute(attrib)
     else:

--- a/microdata.py
+++ b/microdata.py
@@ -21,7 +21,6 @@ def get_items(location, encoding=None):
     except ImportError:
         from urllib import urlopen
 
-    print "Objects in location", location
     dom_builder = html5lib.treebuilders.getTreeBuilder("dom")
     parser = html5lib.HTMLParser(tree=dom_builder)
     tree = parser.parse(urlopen(location), encoding=encoding)
@@ -114,7 +113,7 @@ class URI(object):
         if string.startswith("http://") or string.startswith("https://"):
             self.string = string
         else:
-            self.string = "http://" + domain + string
+            self.string = "/".join(("http:", "", domain, string))
 
     def __eq__(self, other):
         if isinstance(other, URI):

--- a/microdata.py
+++ b/microdata.py
@@ -125,8 +125,11 @@ class URI(object):
 
     @staticmethod
     def get_domain(url_string):
+        """
+        Get the domain _including_ the protocol specified, if any.
+        """
         if "://" in url_string:
-            return url_string.split("/")[2]
+            return "/".join(url_string.split("/")[0:3])
         else:
             return url_string.split("/")[0]
 

--- a/test.py
+++ b/test.py
@@ -71,7 +71,7 @@ class MicrodataParserTest(unittest.TestCase):
         # test case of a nested itemscope
         self.assertTrue(isinstance(item.location, Item))
         self.assertEqual(item.location.itemtype, [URI("http://schema.org/Place")])
-        self.assertEqual(item.location.url, URI("wells-fargo-center.html"))
+        self.assertEqual(item.location.url, URI("wells-fargo-center.html", domain="test-data"))
 
         # address should be a nested item
         self.assertTrue(isinstance(item.location.address, Item))
@@ -82,9 +82,9 @@ class MicrodataParserTest(unittest.TestCase):
         i = json.loads(item.json())
         self.assertEqual(i["properties"]["name"][0].strip(), "Miami Heat at Philadelphia 76ers - Game 3 (Home Game 1)")
         self.assertEqual(i["type"], ["http://schema.org/Event"])
-        self.assertEqual(i["properties"]["url"], ["nba-miami-philidelphia-game3.html"])
+        self.assertEqual(i["properties"]["url"], ["http://test-data/nba-miami-philidelphia-game3.html"])
         self.assertTrue(isinstance(i["properties"]["location"][0], dict))
-        self.assertEqual(i["properties"]["location"][0]["properties"]["url"][0], "wells-fargo-center.html")
+        self.assertEqual(i["properties"]["location"][0]["properties"]["url"][0], "http://test-data/wells-fargo-center.html")
         self.assertTrue(isinstance(i["properties"]["location"][0]["properties"]["address"][0], dict))
         self.assertEqual(i["properties"]["location"][0]["properties"]["address"][0]["properties"]["addressLocality"][0], "Philadelphia")
 

--- a/test.py
+++ b/test.py
@@ -117,7 +117,7 @@ class URITest(unittest.TestCase):
     
     def test_get_domain(self):
         https_start = "https://github.com/edsu/microdata"
-        self.assertEqual("github.com", URI.get_domain(https_start))
+        self.assertEqual("https://github.com", URI.get_domain(https_start))
 
         no_https = "github.com/edsu/microdata"
         self.assertEqual("github.com", URI.get_domain(no_https))

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ class MicrodataParserTest(unittest.TestCase):
     def test_parse(self):
 
         # parse the html for microdata
-        items = get_items(open("test-data/example.html"))
+        items = get_items("test-data/example.html")
 
         # this html should have just one main item
         self.assertTrue(len(items), 1)
@@ -55,7 +55,7 @@ class MicrodataParserTest(unittest.TestCase):
     def test_parse_nested(self):
 
         # parse the html for microdata
-        items = get_items(open("test-data/example-nested.html"))
+        items = get_items("test-data/example-nested.html")
 
         # this html should have just one main item
         self.assertTrue(len(items), 1)
@@ -89,7 +89,7 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertEqual(i["properties"]["location"][0]["properties"]["address"][0]["properties"]["addressLocality"][0], "Philadelphia")
 
     def test_parse_unlinked(self):
-        items = get_items(open("test-data/unlinked.html"))
+        items = get_items("test-data/unlinked.html")
         self.assertEqual(len(items), 2)
 
         i = items[0]
@@ -108,7 +108,7 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertTrue('Whitworth' in i.streetAddress)
 
     def test_skip_level(self):
-        items = get_items(open("test-data/skip-level.html"))
+        items = get_items("test-data/skip-level.html")
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].name, "Jane Doe")
 

--- a/test.py
+++ b/test.py
@@ -112,6 +112,18 @@ class MicrodataParserTest(unittest.TestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].name, "Jane Doe")
 
+
+class URITest(unittest.TestCase):
+    
+    def test_get_domain(self):
+        https_start = "https://github.com/edsu/microdata"
+        self.assertEqual("github.com", URI.get_domain(https_start))
+
+        no_https = "github.com/edsu/microdata"
+        self.assertEqual("github.com", URI.get_domain(no_https))
+
+        plain = "github.com"
+        self.assertEqual(plain, URI.get_domain(plain))
         
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #8.

Instead of passing around the domain, a cleaner way would be to create an object that abstracts the parsing of a document. That way, the domain can be extracted from the constructor into a field and then used by methods that need it. But I think this PR is large enough as it is for #8 so I guess I'll owe the refactor to another PR. :)