### PR TITLE
Use "content" if possible instead of text-data

### DIFF
--- a/microdata.py
+++ b/microdata.py
@@ -205,7 +205,7 @@ def _property_value(e):
     elif attrib:
         value = e.getAttribute(attrib)
     else:
-        value = _text(e)
+        value = e.getAttribute("content") or _text(e)
     return value
 
 


### PR DESCRIPTION
In `<span itemprop="price" content="399.00">399,00</span>` the price should be 399.00 instead of 399,00